### PR TITLE
실습 페이지 UI 뼈대 구성 및 더미 데이터 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { RouterProvider } from 'react-router-dom';
 import AppRouter from './routers/AppRouter';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 function App() { 
   return (

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Logo() {
+  return (
+    <div className="d-flex align-items-center gap-3">
+      <h1 className="h3 mb-0 text-warning">THE ONE</h1>
+      <span className="text-muted">11월 3일 수업</span>
+    </div>
+  );
+}

--- a/src/components/UserName.jsx
+++ b/src/components/UserName.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Badge } from 'react-bootstrap';
+
+export default function UserName({ name }) {
+  return (
+    <Badge bg="warning" text="dark">
+      {name}
+    </Badge>
+  );
+}

--- a/src/pages/Practice.jsx
+++ b/src/pages/Practice.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import Main from './practice/main'
+
+export default function Practice() {
+    return (
+      <Main />
+    )
+}

--- a/src/pages/practice/Answer.jsx
+++ b/src/pages/practice/Answer.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { Card, Button, Form } from 'react-bootstrap';
+
+export default function Answer() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [code, setCode] = useState(
+    `import React from 'react';
+
+export default function BoardDetailPage() {
+  return (
+    <>
+      <h1>BOARDDETAIL</h1>
+      <div>THIS IS BOARDDETAILPAGE</div>
+    </>
+  );
+}`
+  );
+
+  const handleEdit = () => {
+    setIsEditing(!isEditing);
+  };
+
+  return (
+    <Card>
+      <Card.Body>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <Card.Title>모범답안</Card.Title>
+          <Button variant="warning" size="sm" onClick={handleEdit}>
+            {isEditing ? '저장' : '편집'}
+          </Button>
+        </div>
+        {isEditing ? (
+          <Form.Control
+            as="textarea"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            style={{ minHeight: '200px', fontFamily: 'monospace' }}
+          />
+        ) : (
+          <pre className="bg-light p-3 rounded">
+            <code>{code}</code>
+          </pre>
+        )}
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/pages/practice/Assignment.jsx
+++ b/src/pages/practice/Assignment.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Card, Button, Form } from 'react-bootstrap';
+
+export default function Assignment() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [content, setContent] = useState(
+    `1. routes/board/page.js를 사용흐며 마크업에서 부터시오.
+2. 서버와 통신하여 데이터를 조회하시오.
+3. 조회하는 함수는 lib/apis/board.js에 위치하여 사용하시오.`
+  );
+
+  const handleEdit = () => {
+    setIsEditing(!isEditing);
+  };
+
+  return (
+    <Card>
+      <Card.Body>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <Card.Title>실습 - BoardList 페이지</Card.Title>
+          <Button variant="warning" size="sm" onClick={handleEdit}>
+            {isEditing ? '저장' : '편집'}
+          </Button>
+        </div>
+        {isEditing ? (
+          <Form.Control
+            as="textarea"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            style={{ minHeight: '150px' }}
+          />
+        ) : (
+          <div className="ps-3" style={{ whiteSpace: 'pre-line' }}>
+            {content}
+          </div>
+        )}
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/pages/practice/Main.jsx
+++ b/src/pages/practice/Main.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Container, Row, Col, Button } from 'react-bootstrap';
+import Logo from '../../components/logo';
+import Assignment from './Assignment';
+import Answer from './Answer';
+import Submit from './Submit';
+
+export default function Main() {
+  return (
+    <div className="min-vh-100 bg-light">
+      <header className="border-bottom">
+        <Container className="d-flex justify-content-between align-items-center py-3">
+          <Logo />
+          <Button variant="warning">로그아웃</Button>
+        </Container>
+      </header>
+      <main>
+        <Container className="py-4">
+          <Row className="gy-4">
+            <Col xs={12}>
+              <Assignment />
+            </Col>
+            <Col xs={12}>
+              <Answer />
+            </Col>
+            <Col xs={12}>
+              <Submit />
+            </Col>
+          </Row>
+        </Container>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/practice/Submit.jsx
+++ b/src/pages/practice/Submit.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { Card, Button, Form, Modal } from 'react-bootstrap';
+import UserName from '../../components/UserName';
+
+export default function Submit() {
+  const [isTimerRunning, setIsTimerRunning] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(0);
+  const [showTimerModal, setShowTimerModal] = useState(false);
+  const [timerInput, setTimerInput] = useState('10');
+  const [completedUsers, setCompletedUsers] = useState([
+    "조인우", "장우진", "이하늘", "이민선"
+  ]);
+
+  // 타이머 모달 열기
+  const openTimerModal = () => {
+    setShowTimerModal(true);
+  };
+
+  // 타이머 시작
+  const startTimer = () => {
+    const minutes = parseInt(timerInput);
+    if (minutes > 0) {
+      setTimeLeft(minutes * 60);
+      setIsTimerRunning(true);
+      setShowTimerModal(false);
+    } else {
+      alert('유효한 시간을 입력해주세요.');
+    }
+  };
+
+  // 타이머 취소
+  const cancelTimer = () => {
+    setIsTimerRunning(false);
+    setTimeLeft(0);
+  };
+
+  // 완료 처리
+  const handleComplete = () => {
+    alert('과제가 완료되었습니다!');
+  };
+
+  useEffect(() => {
+    let timer;
+    if (isTimerRunning && timeLeft > 0) {
+      timer = setInterval(() => {
+        setTimeLeft((prev) => prev - 1);
+      }, 1000);
+    } else if (timeLeft === 0 && isTimerRunning) {
+      setIsTimerRunning(false);
+    }
+
+    return () => clearInterval(timer);
+  }, [isTimerRunning, timeLeft]);
+
+  // 시간을 mm:ss 형식으로 변환
+  const formatTime = (seconds) => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <Card>
+      <Card.Body>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <Card.Title>시간안에 완료한 사람</Card.Title>
+          <div className="d-flex align-items-center gap-2">
+            {!isTimerRunning && timeLeft === 0 ? (
+              <Button variant="primary" size="sm" onClick={openTimerModal}>
+                타이머 시작
+              </Button>
+            ) : (
+              <>
+                <span className="text-muted">
+                  타이머 {formatTime(timeLeft)}
+                </span>
+                <Button 
+                  variant="danger" 
+                  size="sm" 
+                  onClick={cancelTimer}
+                >
+                  타이머 중지
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="d-flex flex-wrap gap-2 mb-3">
+          {completedUsers.map((user, index) => (
+            <UserName key={index} name={user} />
+          ))}
+        </div>
+        {isTimerRunning && (
+          <div className="text-center">
+            <Button 
+              variant="success" 
+              onClick={handleComplete}
+              disabled={!isTimerRunning}
+            >
+              완료
+            </Button>
+          </div>
+        )}
+      </Card.Body>
+
+      {/* 타이머 설정 모달 */}
+      <Modal show={showTimerModal} onHide={() => setShowTimerModal(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>타이머 설정</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Group>
+            <Form.Label>시간 설정 (분)</Form.Label>
+            <Form.Control
+              type="number"
+              value={timerInput}
+              onChange={(e) => setTimerInput(e.target.value)}
+              min="1"
+              max="60"
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowTimerModal(false)}>
+            취소
+          </Button>
+          <Button variant="primary" onClick={startTimer}>
+            시작
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </Card>
+  );
+}

--- a/src/routers/AppRouter.jsx
+++ b/src/routers/AppRouter.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import Home from '../pages/Home';
 import NotFound from '../pages/NotFound';
+import Practice from '../pages/Practice';
 
 const AppRouter = createBrowserRouter([
     {
@@ -9,6 +10,11 @@ const AppRouter = createBrowserRouter([
         element: <Home />,
         index: true,
       },
+    {
+      path: '/practice',
+      element: <Practice />,
+      index: true,
+    },
     {
       path: '*',
       element: <NotFound />,


### PR DESCRIPTION
## 개요
- 실습 페이지의 UI 뼈대 코드를 작성하고, 더미 데이터를 활용해 기본 레이아웃을 구현
- 이 작업은 실제 백엔드 API 요청 없이 화면 구성과 컴포넌트 배치를 확인할 수 있도록 더미 데이터를 사용하여 구성

## 작업사항
#8 

## 변경로직
- Answer, Assignment, Submit 컴포넌트 추가 및 기본 UI 레이아웃 구현
- Logo, UserName 등의 공통 컴포넌트 추가
- Practice 페이지에 라우터 설정 및 네비게이션 적용
- 전역 스타일링을 위해 `App.jsx`에 Bootstrap 라이브러리 임포트