### PR TITLE
Nginx API 프록시 설정

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,36 +1,33 @@
-# Nginx의 이벤트 처리를 정의. 필수 블록으로 없으면 에러 발생
+# 필수 이벤트 블록
 events {}
 
-# HTTP 요청을 처리하는 블록을 정의. 모든 서버 설정을 포함
+# HTTP 블록
 http {
     # MIME 타입 설정 파일 포함
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    # 요청을 받을 포트를 80번으로 정의. 외부에서 접근할 수 있도록 설정
     server {
         listen 80;
 
-        # 서버 이름을 localhost로 정의. 특정 도메인에서만 요청을 받기 위해 필요
+        # 서버 이름 설정
         server_name localhost;
 
-        # 정적 파일을 찾을 기본 경로를 정의. Nginx가 빌드된 정적 파일을 제공할 위치
+        # 정적 파일의 기본 경로 설정
         root /usr/share/nginx/html;
 
-        # 루트 경로 요청을 처리하며, 파일이 없으면 index.html로 대체.
-        # SPA에서 모든 경로를 index.html로 리디렉션하여 프론트엔드 라우터가 처리하게 함
+        # SPA를 위한 기본 라우팅 설정
         location / {
             try_files $uri /index.html;
         }
 
-        # 404 에러 발생 시 index.html로 대체.
-        # 없는 경로에 대한 요청이 와도 SPA가 라우팅을 처리하도록 함
-        error_page 404 /index.html;
-
-        # index.html은 내부적으로만 접근 가능하게 설정.
-        # 외부에서 직접 접근하지 못하게 하여 불필요한 요청을 막음
-        location = /index.html {
-            internal;
+        # API 요청을 백엔드 서버로 프록시
+        location /api/ {
+            proxy_pass http://host.docker.internal:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }

--- a/src/pages/home/Login.jsx
+++ b/src/pages/home/Login.jsx
@@ -25,7 +25,7 @@ export default function Login() {
 
     try {
       const response = await axios.post(
-        'http://localhost:8080/api/login',
+        '/api/auth/login',
         formData
       );
       setSuccessMessage('로그인 성공!');


### PR DESCRIPTION
## 개요

- Nginx를 통해 `/api`로 시작하는 요청을 백엔드로 프록시하도록 설정

## 작업사항

#16 

## 변경로직

- Nginx 설정 파일 수정: `/api` 경로의 요청을 백엔드 서버로 프록시하도록 구성.