### PR TITLE
Docker 네트워크 설정을 위한 GitHub Actions 및 Nginx 구성 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,17 +35,13 @@ jobs:
         key: ${{ secrets.EC2_KEY }}
         port: 22
         script: |
-          # Docker 설치 확인
-          if ! command -v docker &> /dev/null
-          then
-              echo "Docker not installed. Installing..."
-              sudo amazon-linux-extras install docker -y
-              sudo service docker start
-              sudo usermod -a -G docker ec2-user
-          fi
+          # backend_network가 없으면 생성
+          docker network ls | grep backend_network || docker network create backend_network
           
           # 최신 이미지를 pull하고 기존 컨테이너를 중단 및 삭제 후 새로 시작
           docker pull ${{ secrets.DOCKER_IMAGE_NAME }}
           docker stop my-app || true
           docker rm my-app || true
-          docker run -d --name my-app -p 80:80 ${{ secrets.DOCKER_IMAGE_NAME }}
+          
+          # 프론트엔드 컨테이너를 backend_network에 연결하여 실행
+          docker run -d --name my-app --network backend_network -p 80:80 ${{ secrets.DOCKER_IMAGE_NAME }}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,36 +1,33 @@
-# Nginx의 이벤트 처리를 정의. 필수 블록으로 없으면 에러 발생
+# 필수 이벤트 블록
 events {}
 
-# HTTP 요청을 처리하는 블록을 정의. 모든 서버 설정을 포함
+# HTTP 블록
 http {
     # MIME 타입 설정 파일 포함
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    # 요청을 받을 포트를 80번으로 정의. 외부에서 접근할 수 있도록 설정
     server {
         listen 80;
 
-        # 서버 이름을 localhost로 정의. 특정 도메인에서만 요청을 받기 위해 필요
+        # 서버 이름 설정
         server_name localhost;
 
-        # 정적 파일을 찾을 기본 경로를 정의. Nginx가 빌드된 정적 파일을 제공할 위치
+        # 정적 파일의 기본 경로 설정
         root /usr/share/nginx/html;
 
-        # 루트 경로 요청을 처리하며, 파일이 없으면 index.html로 대체.
-        # SPA에서 모든 경로를 index.html로 리디렉션하여 프론트엔드 라우터가 처리하게 함
+        # SPA를 위한 기본 라우팅 설정
         location / {
             try_files $uri /index.html;
         }
 
-        # 404 에러 발생 시 index.html로 대체.
-        # 없는 경로에 대한 요청이 와도 SPA가 라우팅을 처리하도록 함
-        error_page 404 /index.html;
-
-        # index.html은 내부적으로만 접근 가능하게 설정.
-        # 외부에서 직접 접근하지 못하게 하여 불필요한 요청을 막음
-        location = /index.html {
-            internal;
+        # API 요청을 백엔드 서버로 프록시
+        location /api/ {
+            proxy_pass http://app:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
## **개요**

`host.docker.internal`이 EC2 환경에서 인식되지 않아, Docker 네트워크(`backend_network`)를 사용하여 컨테이너 간 통신 문제를 해결

## **작업사항**

#18 

## **변경로직**

- GitHub Actions에서 Docker 네트워크 설정 추가
- Nginx 설정 파일 수정 및 Docker 네트워크 기반으로 백엔드 API 프록시 구성