### PR TITLE
Nginx에서 SSE 연결 유지 문제

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,10 +24,13 @@ http {
         # API 요청을 백엔드 서버로 프록시
         location /api/ {
             proxy_pass http://app:8080;
+            proxy_http_version 1.1;  # HTTP/1.1 사용
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "keep-alive";  # 연결 유지
+            proxy_read_timeout 300;  # 타임아웃을 5분으로 설정
         }
     }
 }


### PR DESCRIPTION
## 개요

Nginx 설정을 수정하여 Server-Sent Events(SSE) 연결을 안정적으로 유지하도록 개선

## 작업사항

#35 

## 변경로직

- Nginx의 `location /api/` 블록에 SSE 연결을 유지하기 위한 설정 추가
- `proxy_http_version`을 1.1로 설정하여 HTTP/1.1 사용
- `Connection` 헤더를 "keep-alive"로 설정하여 연결 유지
- `proxy_read_timeout` 값을 증가시켜 타임아웃 문제 해결