### PR TITLE
실습 상세 페이지 데이터 연동 및 상태 관리 기능 구현

### DIFF
--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom'; // useNavigate 훅을 사용하여 리디렉션
 import './components.css';
 
-export default function Logo() {
+export default function Logo({ text }) {
   const navigate = useNavigate(); // useNavigate 훅을 사용하여 리디렉션
 
   const handleLogout = () => {
@@ -16,12 +16,8 @@ export default function Logo() {
   return (
     <nav id="logo-bar" className="navbar bg-body-tertiary">
       <div className="container-fluid">
-        <img
-          src="/images/main_logo.png"
-          alt="Logo"
-          width="180"
-          height="55"
-        />
+        <img src="/images/main_logo.png" alt="Logo" width="180" height="55" />
+        {text && <span className="mx-auto">{text}</span>}
         {/* 로그아웃 버튼 클릭 시 handleLogout 호출 */}
         <button
           id="logo-button"

--- a/src/pages/practice/Answer.jsx
+++ b/src/pages/practice/Answer.jsx
@@ -1,23 +1,38 @@
 import React, { useState } from 'react';
 import { Card, Button, Form } from 'react-bootstrap';
+import axios from 'axios';
 
-export default function Answer() {
+export default function Answer({ code: initialCode, practiceId, onRefresh }) {
   const [isEditing, setIsEditing] = useState(false);
-  const [code, setCode] = useState(
-    `import React from 'react';
+  const [code, setCode] = useState(initialCode);
 
-export default function BoardDetailPage() {
-  return (
-    <>
-      <h1>BOARDDETAIL</h1>
-      <div>THIS IS BOARDDETAILPAGE</div>
-    </>
-  );
-}`
-  );
+  const handleSave = async () => {
+    const token = localStorage.getItem('accessToken');
+    try {
+      await axios.put(
+        `/api/practices/${practiceId}/answer`,
+        JSON.stringify(code),
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      setIsEditing(false);
+      if (onRefresh) onRefresh(); // 변경사항 반영을 위해 데이터 재요청
+    } catch (error) {
+      console.error('Error updating answer:', error);
+      alert('모범답안을 저장하는 데 문제가 발생했습니다.');
+    }
+  };
 
   const handleEdit = () => {
-    setIsEditing(!isEditing);
+    if (isEditing) {
+      handleSave(); // 편집 모드 종료 시 저장
+    } else {
+      setIsEditing(true); // 편집 모드 시작
+    }
   };
 
   return (

--- a/src/pages/practice/Assignment.jsx
+++ b/src/pages/practice/Assignment.jsx
@@ -1,23 +1,49 @@
 import React, { useState } from 'react';
 import { Card, Button, Form } from 'react-bootstrap';
+import axios from 'axios';
 
-export default function Assignment() {
+export default function Assignment({
+  content: initialContent,
+  practiceId,
+  onRefresh,
+}) {
   const [isEditing, setIsEditing] = useState(false);
-  const [content, setContent] = useState(
-    `1. routes/board/page.js를 사용흐며 마크업에서 부터시오.
-2. 서버와 통신하여 데이터를 조회하시오.
-3. 조회하는 함수는 lib/apis/board.js에 위치하여 사용하시오.`
-  );
+  const [content, setContent] = useState(initialContent);
+
+  const handleSave = async () => {
+    const token = localStorage.getItem('accessToken');
+    try {
+      await axios.put(
+        `/api/practices/${practiceId}/assignment`,
+        JSON.stringify(content),
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      setIsEditing(false);
+      if (onRefresh) onRefresh(); // 변경사항 반영을 위해 데이터 재요청
+    } catch (error) {
+      console.error('Error updating assignment:', error);
+      alert('실습 내용을 저장하는 데 문제가 발생했습니다.');
+    }
+  };
 
   const handleEdit = () => {
-    setIsEditing(!isEditing);
+    if (isEditing) {
+      handleSave(); // 편집 모드 종료 시 저장
+    } else {
+      setIsEditing(true); // 편집 모드 시작
+    }
   };
 
   return (
     <Card>
       <Card.Body>
         <div className="d-flex justify-content-between align-items-center mb-3">
-          <Card.Title>실습 - BoardList 페이지</Card.Title>
+          <Card.Title>실습</Card.Title>
           <Button variant="warning" size="sm" onClick={handleEdit}>
             {isEditing ? '저장' : '편집'}
           </Button>

--- a/src/pages/practice/Main.jsx
+++ b/src/pages/practice/Main.jsx
@@ -36,7 +36,7 @@ export default function Main({ practiceId }) {
   return (
     <div className="min-vh-100 bg-light">
       <header className="border-bottom">
-        <Logo />
+        <Logo text={practiceData.title} />
       </header>
       <main>
         <Container className="py-4">

--- a/src/pages/practice/Main.jsx
+++ b/src/pages/practice/Main.jsx
@@ -1,11 +1,38 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import Logo from '../../components/Logo';
 import Assignment from './Assignment';
 import Answer from './Answer';
 import Submit from './Submit';
 
 export default function Main({ practiceId }) {
+  const [practiceData, setPracticeData] = useState(null);
+  const navigate = useNavigate();
+
+  const fetchPracticeData = async () => {
+    const token = localStorage.getItem('accessToken');
+    try {
+      const response = await axios.get(`/api/practices/${practiceId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setPracticeData(response.data);
+    } catch (error) {
+      console.error('Error fetching practice data:', error);
+      alert('해당하는 실습이 없습니다!');
+      navigate('/main');
+    }
+  };
+
+  useEffect(() => {
+    fetchPracticeData();
+  }, [practiceId]);
+
+  if (!practiceData) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div className="min-vh-100 bg-light">
       <header className="border-bottom">
@@ -15,13 +42,21 @@ export default function Main({ practiceId }) {
         <Container className="py-4">
           <Row className="gy-4">
             <Col xs={12}>
-              <Assignment practiceId={practiceId} />
+              <Assignment
+                content={practiceData.assignment}
+                practiceId={practiceId}
+                onRefresh={fetchPracticeData}
+              />
             </Col>
             <Col xs={12}>
-              <Answer practiceId={practiceId} />
+              <Answer
+                code={practiceData.answer}
+                practiceId={practiceId}
+                onRefresh={fetchPracticeData}
+              />
             </Col>
             <Col xs={12}>
-              <Submit practiceId={practiceId} />
+              <Submit usersPractices={practiceData.usersPractices} />
             </Col>
           </Row>
         </Container>

--- a/src/pages/practice/Submit.jsx
+++ b/src/pages/practice/Submit.jsx
@@ -1,12 +1,55 @@
 import React, { useState } from 'react';
-import { Card, Row, Col } from 'react-bootstrap';
+import { Card, Row, Col, Button } from 'react-bootstrap';
 import UserName from '../../components/UserName';
 import Timer from './Timer';
+import axios from 'axios';
 
-export default function Submit({ practiceId }) {
-  const [completedUsers, setCompletedUsers] = useState([
-    "조인우", "장우진", "이하늘", "이민선"
-  ]);
+export default function Submit({ usersPractices, practiceId, onRefresh }) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false); // 취소 요청 상태
+
+  const handleComplete = async () => {
+    setIsSubmitting(true);
+    const token = localStorage.getItem('accessToken');
+    try {
+      await axios.post(
+        `/api/practices/${practiceId}/users_practices`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      alert('완료가 성공적으로 기록되었습니다!');
+      if (onRefresh) onRefresh(); // 데이터 갱신
+    } catch (error) {
+      console.error('Error completing practice:', error);
+      alert('완료 요청에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCancel = async (userId) => {
+    setIsCancelling(true);
+    const token = localStorage.getItem('accessToken');
+    try {
+      await axios.delete(`/api/practices/${practiceId}/users_practices`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        data: { userId }, // DELETE 요청 본문에 userId 포함
+      });
+      alert('완료 기록이 취소되었습니다!');
+      if (onRefresh) onRefresh(); // 데이터 갱신
+    } catch (error) {
+      console.error('Error cancelling completion:', error);
+      alert('취소 요청에 실패했습니다.');
+    } finally {
+      setIsCancelling(false);
+    }
+  };
 
   return (
     <Card className="shadow-sm mb-4">
@@ -17,16 +60,24 @@ export default function Submit({ practiceId }) {
           </Col>
         </Row>
 
-        {/* 완료한 사용자 리스트 */}
         <div className="d-flex flex-wrap gap-2 mb-4">
-          {completedUsers.map((user, index) => (
-            <UserName key={index} name={user} />
+          {usersPractices.map((user, index) => (
+            <UserName
+              key={index}
+              name={user.userName}
+              onClick={() => handleCancel(user.userId)} // 사용자 이름 클릭 시 취소 요청
+              style={{ cursor: 'pointer', color: 'red' }}
+              disabled={isCancelling} // 취소 요청 중이면 비활성화
+            />
           ))}
         </div>
 
-        {/* Timer 컴포넌트 */}
         <div className="text-center mb-3">
-          <Timer practiceId={practiceId} />
+          <Timer
+            practiceId={practiceId}
+            onCompleteClick={handleComplete}
+            isSubmitting={isSubmitting}
+          />
         </div>
       </Card.Body>
     </Card>

--- a/src/pages/practice/Timer.jsx
+++ b/src/pages/practice/Timer.jsx
@@ -14,7 +14,7 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-export default function Timer({ practiceId }) {
+export default function Timer({ practiceId, onCompleteClick, isSubmitting }) {
   const [timeLeft, setTimeLeft] = useState(0); // 남은 시간 상태
   const [timerState, setTimerState] = useState('stopped'); // 타이머 상태 (running, stopped)
   const [showTimerModal, setShowTimerModal] = useState(false); // 타이머 설정 모달 표시 상태
@@ -157,7 +157,8 @@ export default function Timer({ practiceId }) {
             <Col xs="auto">
               <Button
                 variant="warning"
-                size="sm"
+                onClick={onCompleteClick} // props로 받은 함수 호출
+                disabled={isSubmitting} // 요청 중일 때 비활성화
                 className="text-white fw-bold"
               >
                 완료


### PR DESCRIPTION
## 개요

- 실습 상세 페이지에서 더미 데이터를 실제 API 데이터로 연동하여 사용자에게 실시간으로 데이터를 제공

## 작업사항

#37

## 변경로직

- **실습 상세 데이터 연동**: `GET /api/practices/{id}` API 연동으로 상세 데이터 표시.
- **답안 및 실습 내용 수정 기능**: 
  - `PUT /api/practices/{id}/answer`로 답안 수정.
  - `PUT /api/practices/{id}/assignment`로 실습 내용 수정.
  - 수정 후 데이터 재요청으로 변경 사항 반영.
- **완료 상태 기록 기능**: 
  - `POST /api/practices/{id}/users_practices`로 완료 상태 기록.
  - 타이머 실행 중에만 완료 버튼 활성화.
- **완료 상태 취소 기능**: 
  - `DELETE /api/practices/{id}/users_practices`로 완료 상태 취소.
  - 완료된 사용자 이름 클릭 시 실행.
- **요청 후 데이터 갱신**: 각 요청 후 `GET /api/practices/{id}`를 통해 최신 데이터 반영.
- **요청 중 상태 관리**: `isSubmitting`, `isCancelling` 상태로 중복 요청 방지 및 로딩 상태 관리.
- **에러 처리 및 페이지 리디렉션**: 요청 실패 시 사용자 알림 및 필요한 경우 `/main`으로 리디렉션.