### PR TITLE
실습 상세 페이지 오류 수정

### DIFF
--- a/src/pages/practice/Answer.jsx
+++ b/src/pages/practice/Answer.jsx
@@ -1,17 +1,19 @@
 import React, { useState } from 'react';
 import { Card, Button, Form } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
-export default function Answer({ code: initialCode, practiceId, onRefresh }) {
+export default function Answer({ code: initialCode, practiceId }) {
   const [isEditing, setIsEditing] = useState(false);
   const [code, setCode] = useState(initialCode);
+  const navigate = useNavigate();
 
   const handleSave = async () => {
     const token = localStorage.getItem('accessToken');
     try {
       await axios.put(
         `/api/practices/${practiceId}/answer`,
-        JSON.stringify(code),
+        { newContent: code },
         {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -20,7 +22,7 @@ export default function Answer({ code: initialCode, practiceId, onRefresh }) {
         }
       );
       setIsEditing(false);
-      if (onRefresh) onRefresh(); // 변경사항 반영을 위해 데이터 재요청
+      navigate(0);
     } catch (error) {
       console.error('Error updating answer:', error);
       alert('모범답안을 저장하는 데 문제가 발생했습니다.');

--- a/src/pages/practice/Assignment.jsx
+++ b/src/pages/practice/Assignment.jsx
@@ -1,21 +1,19 @@
 import React, { useState } from 'react';
 import { Card, Button, Form } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
-export default function Assignment({
-  content: initialContent,
-  practiceId,
-  onRefresh,
-}) {
+export default function Assignment({ content: initialContent, practiceId }) {
   const [isEditing, setIsEditing] = useState(false);
   const [content, setContent] = useState(initialContent);
+  const navigate = useNavigate();
 
   const handleSave = async () => {
     const token = localStorage.getItem('accessToken');
     try {
       await axios.put(
         `/api/practices/${practiceId}/assignment`,
-        JSON.stringify(content),
+        { newContent: content },
         {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -24,7 +22,7 @@ export default function Assignment({
         }
       );
       setIsEditing(false);
-      if (onRefresh) onRefresh(); // 변경사항 반영을 위해 데이터 재요청
+      navigate(0);
     } catch (error) {
       console.error('Error updating assignment:', error);
       alert('실습 내용을 저장하는 데 문제가 발생했습니다.');

--- a/src/pages/practice/Main.jsx
+++ b/src/pages/practice/Main.jsx
@@ -45,18 +45,16 @@ export default function Main({ practiceId }) {
               <Assignment
                 content={practiceData.assignment}
                 practiceId={practiceId}
-                onRefresh={fetchPracticeData}
               />
             </Col>
             <Col xs={12}>
-              <Answer
-                code={practiceData.answer}
+              <Answer code={practiceData.answer} practiceId={practiceId} />
+            </Col>
+            <Col xs={12}>
+              <Submit
+                usersPractices={practiceData.usersPractices}
                 practiceId={practiceId}
-                onRefresh={fetchPracticeData}
               />
-            </Col>
-            <Col xs={12}>
-              <Submit usersPractices={practiceData.usersPractices} />
             </Col>
           </Row>
         </Container>

--- a/src/pages/practice/Submit.jsx
+++ b/src/pages/practice/Submit.jsx
@@ -1,12 +1,33 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Card, Row, Col, Button } from 'react-bootstrap';
 import UserName from '../../components/UserName';
+import { useNavigate } from 'react-router-dom';
 import Timer from './Timer';
 import axios from 'axios';
 
 export default function Submit({ usersPractices, practiceId, onRefresh }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isCancelling, setIsCancelling] = useState(false); // 취소 요청 상태
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [userInfo, setUserInfo] = useState(null); // 로그인 사용자 정보
+  const navigate = useNavigate();
+
+  // 사용자 정보 가져오기
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await axios.get('/api/auth/validate-token', {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+          },
+        });
+        setUserInfo(response.data);
+      } catch (error) {
+        console.error('Failed to fetch user info', error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
 
   const handleComplete = async () => {
     setIsSubmitting(true);
@@ -22,7 +43,7 @@ export default function Submit({ usersPractices, practiceId, onRefresh }) {
         }
       );
       alert('완료가 성공적으로 기록되었습니다!');
-      if (onRefresh) onRefresh(); // 데이터 갱신
+      navigate(0);
     } catch (error) {
       console.error('Error completing practice:', error);
       alert('완료 요청에 실패했습니다.');
@@ -31,7 +52,8 @@ export default function Submit({ usersPractices, practiceId, onRefresh }) {
     }
   };
 
-  const handleCancel = async (userId) => {
+  const handleCancel = async () => {
+    if (!userInfo) return; // 사용자 정보가 없으면 실행 중단
     setIsCancelling(true);
     const token = localStorage.getItem('accessToken');
     try {
@@ -39,10 +61,9 @@ export default function Submit({ usersPractices, practiceId, onRefresh }) {
         headers: {
           Authorization: `Bearer ${token}`,
         },
-        data: { userId }, // DELETE 요청 본문에 userId 포함
       });
       alert('완료 기록이 취소되었습니다!');
-      if (onRefresh) onRefresh(); // 데이터 갱신
+      navigate(0);
     } catch (error) {
       console.error('Error cancelling completion:', error);
       alert('취소 요청에 실패했습니다.');
@@ -51,12 +72,26 @@ export default function Submit({ usersPractices, practiceId, onRefresh }) {
     }
   };
 
+  // 본인이 완료한 기록이 있는지 확인
+  const hasCompleted = usersPractices.some(
+    (user) => userInfo && user.userId === userInfo.id
+  );
+
   return (
     <Card className="shadow-sm mb-4">
       <Card.Body>
         <Row className="mb-3">
-          <Col>
+          <Col className="d-flex align-items-center justify-content-between">
             <Card.Title>시간안에 완료한 사람</Card.Title>
+            {hasCompleted && (
+              <Button
+                variant="danger"
+                onClick={handleCancel}
+                disabled={isCancelling}
+              >
+                제출 취소
+              </Button>
+            )}
           </Col>
         </Row>
 
@@ -65,9 +100,9 @@ export default function Submit({ usersPractices, practiceId, onRefresh }) {
             <UserName
               key={index}
               name={user.userName}
-              onClick={() => handleCancel(user.userId)} // 사용자 이름 클릭 시 취소 요청
-              style={{ cursor: 'pointer', color: 'red' }}
-              disabled={isCancelling} // 취소 요청 중이면 비활성화
+              style={{
+                color: user.userId === userInfo?.id ? 'blue' : 'black',
+              }}
             />
           ))}
         </div>


### PR DESCRIPTION
## 개요

- 실습 상세 페이지에서 발생한 오류 수정

## 작업사항

#44 

## 변경로직

1. **`practiceId` 전달 문제 해결**  
   - `practiceId`가 props로 제대로 전달되지 않아 제출 완료/취소 기능이 동작하지 않는 문제를 수정

2. **제출 완료 시 취소 버튼 활성화 구현**  
   - 사용자가 제출 완료 버튼을 누르면 제출된 사용자 목록에서 본인의 이름을 확인하고, **취소 버튼**이 활성화되도록 구현

3. **실시간 데이터 반영을 위한 새로고침 적용**  
   - 문제 편집 및 작업 후 **navigate(0)** 을 통해 페이지를 새로고침하여 최신 데이터를 반영하도록 수정
