### PR TITLE
메인 페이지 및 실습 상세 페이지 비인가 접근 방지

### DIFF
--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -3,6 +3,8 @@ import Question from './Question';
 import Honey from './Honey';
 import BoardList from './BoardList';
 import BoardPlusButton from './BoardPlusButton';
+import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 import PageButton from './PageButton';
 
 import './main.css';
@@ -10,6 +12,17 @@ import { Col, Container } from 'react-bootstrap';
 import { Row } from 'react-bootstrap';
 
 export default function Main() {
+  const navigate = useNavigate();
+
+  // 인증되지 않았을 경우 로그인 페이지로 리디렉션
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+
+    if (!accessToken) {
+      navigate('/');
+    }
+  }, [navigate]);
+
   return (
     <div className="content">
       <Logo></Logo>

--- a/src/pages/practice/Main.jsx
+++ b/src/pages/practice/Main.jsx
@@ -14,10 +14,15 @@ export default function Main({ practiceId }) {
   const fetchPracticeData = async () => {
     const token = localStorage.getItem('accessToken');
     try {
-      const response = await axios.get(`/api/practices/${practiceId}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      setPracticeData(response.data);
+      if (!token) {
+        // 인증되지 않았을 경우 로그인 페이지로 리디렉션
+        navigate('/');
+      } else {
+        const response = await axios.get(`/api/practices/${practiceId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setPracticeData(response.data);
+      }
     } catch (error) {
       console.error('Error fetching practice data:', error);
       alert('해당하는 실습이 없습니다!');


### PR DESCRIPTION
## 개요

- 인증되지 않은 사용자가 메인 페이지나 실습 상세 페이지에 접근하는 것을 방지하기 위해, JWT 토큰이 없을 경우 로그인 페이지로 리다이렉트 처리하는 기능을 구현

## 작업사항

#47 

## 변경로직

- 컴포넌트 렌더링 시 JWT 토큰 존재 여부를 확인.
- JWT 토큰이 없을 경우 `navigate`를 통해 로그인 페이지로 이동.
- 인증된 사용자만 메인 페이지 및 실습 상세 페이지에 접근 가능.